### PR TITLE
fix: change Address to AddressBase32

### DIFF
--- a/spec/core/network/schemas/ChainPropertiesDTO.yml
+++ b/spec/core/network/schemas/ChainPropertiesDTO.yml
@@ -102,7 +102,7 @@ properties:
     description: Percentage of the harvested fee that is collected by the network.
     example: "5"
   harvestNetworkFeeSinkAddress:
-    $ref: "../../../schemas/AddressBase32.yml"
+    $ref: "../../../schemas/Address.yml"
     description: Address of the harvest network fee sink account.
     example: "SDKDPA36TE53BO24FD4KA6OPGOUSEVOU3O5SIFI"
   blockPruneInterval:

--- a/spec/parameters/path/address.yml
+++ b/spec/parameters/path/address.yml
@@ -3,5 +3,5 @@ in: path
 description: Account address.
 required: true
 schema:
-  $ref: "../../schemas/AddressBase32.yml"
+  $ref: "../../schemas/Address.yml"
 

--- a/spec/parameters/path/sourceAddress.yml
+++ b/spec/parameters/path/sourceAddress.yml
@@ -3,4 +3,4 @@ in: path
 description: Account address.
 required: true
 schema:
-  $ref: "../../schemas/AddressBase32.yml"
+  $ref: "../../schemas/Address.yml"

--- a/spec/parameters/query/address.yml
+++ b/spec/parameters/query/address.yml
@@ -1,8 +1,8 @@
 name: address
 in: query
 description: |
-  Filter by address involved in the transaction. 
+  Filter by address involved in the transaction.
   An account's address is considered to be involved in the transaction when the account is the sender, recipient, or it is required to cosign the transaction.
   This filter cannot be combined with ``recipientAddress`` and ``signerPublicKey`` query params.
 schema:
-  $ref: "../../schemas/AddressBase32.yml"
+  $ref: "../../schemas/Address.yml"

--- a/spec/parameters/query/beneficiaryAddress.yml
+++ b/spec/parameters/query/beneficiaryAddress.yml
@@ -2,4 +2,4 @@ name: beneficiaryAddress
 description: Filter by beneficiary address.
 in: query
 schema:
-  $ref: "../../schemas/AddressBase32.yml"
+  $ref: "../../schemas/Address.yml"

--- a/spec/parameters/query/ownerAddress.yml
+++ b/spec/parameters/query/ownerAddress.yml
@@ -2,4 +2,4 @@ name: ownerAddress
 in: query
 description: Filter by owner address.
 schema:
-  $ref: "../../schemas/AddressBase32.yml"
+  $ref: "../../schemas/Address.yml"

--- a/spec/parameters/query/recipientAddress.yml
+++ b/spec/parameters/query/recipientAddress.yml
@@ -2,4 +2,4 @@ name: recipientAddress
 in: query
 description: Filter by address of the account receiving the transaction.
 schema:
-  $ref: "../../schemas/AddressBase32.yml"
+  $ref: "../../schemas/Address.yml"

--- a/spec/parameters/query/senderAddress.yml
+++ b/spec/parameters/query/senderAddress.yml
@@ -2,4 +2,4 @@ name: senderAddress
 in: query
 description: Filter by address sending mosaics.
 schema:
-  $ref: "../../schemas/AddressBase32.yml"
+  $ref: "../../schemas/Address.yml"

--- a/spec/parameters/query/sourceAddress.yml
+++ b/spec/parameters/query/sourceAddress.yml
@@ -2,4 +2,4 @@ name: sourceAddress
 in: query
 description: Filter by address sending the metadata entry.
 schema:
-  $ref: "../../schemas/AddressBase32.yml"
+  $ref: "../../schemas/Address.yml"

--- a/spec/parameters/query/targetAddress.yml
+++ b/spec/parameters/query/targetAddress.yml
@@ -2,4 +2,4 @@ name: targetAddress
 in: query
 description: Filter by target address.
 schema:
-  $ref: "../../schemas/AddressBase32.yml"
+  $ref: "../../schemas/Address.yml"

--- a/spec/plugins/mosaic/schemas/MosaicNetworkPropertiesDTO.yml
+++ b/spec/plugins/mosaic/schemas/MosaicNetworkPropertiesDTO.yml
@@ -13,7 +13,7 @@ properties:
     description: Maximum mosaic divisibility.
     example: "6"
   mosaicRentalFeeSinkAddress:
-    $ref: "../../../schemas/AddressBase32.yml"
+    $ref: "../../../schemas/Address.yml"
     description: Address of the mosaic rental fee sink account.
     example: SDKDPA36TE53BO24FD4KA6OPGOUSEVOU3O5SIFI
   mosaicRentalFee:

--- a/spec/plugins/namespace/schemas/NamespaceNetworkPropertiesDTO.yml
+++ b/spec/plugins/namespace/schemas/NamespaceNetworkPropertiesDTO.yml
@@ -29,7 +29,7 @@ properties:
     description: Reserved root namespaces that cannot be claimed.
     example: xem, nem, user, account, org, com, biz, net, edu, mil, gov, info
   namespaceRentalFeeSinkAddress:
-    $ref: "../../../schemas/AddressBase32.yml"
+    $ref: "../../../schemas/Address.yml"
     description: Address of the namespace rental fee sink account.
     example: SDTZ23JBJZP3GTKKM2P6FYCMXS6RQYPB6R477TQ
   rootNamespaceRentalFeePerBlock:

--- a/spec/request_bodies/schemas/accountIds.yml
+++ b/spec/request_bodies/schemas/accountIds.yml
@@ -9,4 +9,4 @@ properties:
     type: array
     description: Array of addresses.
     items:
-      $ref: "../../schemas/AddressBase32.yml"
+      $ref: "../../schemas/Address.yml"

--- a/spec/request_bodies/schemas/addresses.yml
+++ b/spec/request_bodies/schemas/addresses.yml
@@ -4,4 +4,4 @@ properties:
     type: array
     description: Array of addresses.
     items:
-      $ref: "../../schemas/AddressBase32.yml"
+      $ref: "../../schemas/Address.yml"

--- a/spec/schemas/Address.yml
+++ b/spec/schemas/Address.yml
@@ -1,4 +1,3 @@
 type: string
-format: hex
-description: Address expressed in hexadecimal base.
-example: 9081FCCB41F8C8409A9B99E485E0E28D23BD6304EF7215E0
+description: Address encoded using a 32-character set.
+example: TADP6C2GVEG654OP5LZI32P2GYJSCMEGQBYB7QY

--- a/spec/schemas/AddressBase32.yml
+++ b/spec/schemas/AddressBase32.yml
@@ -1,3 +1,0 @@
-type: string
-description: Address encoded using a 32-character set.
-example: SAAA244WMCB2JXGNQTQHQOS45TGBFF4V2MJBVOQ

--- a/spec/schemas/UnresolvedAddress.yml
+++ b/spec/schemas/UnresolvedAddress.yml
@@ -1,5 +1,4 @@
 type: string
-description: |
-  Address expressed in hexadecimal base. If the bit 0 of byte 0 is not set (like in 0x90), then it is a
-  regular address. Else (e.g. 0x91) it represents a namespace id which starts at byte 1.
-example: 90340017CFF3DD2BCF3B2670CDCB9FC8C75754E2325F297C
+anyOf:
+    - $ref: "./NamespaceId.yml"
+    - $ref: "./Address.yml"

--- a/spec/schemas/UnresolvedAddress.yml
+++ b/spec/schemas/UnresolvedAddress.yml
@@ -1,4 +1,3 @@
 type: string
 anyOf:
-    - $ref: "./NamespaceId.yml"
     - $ref: "./Address.yml"

--- a/spec/schemas/_index.yml
+++ b/spec/schemas/_index.yml
@@ -1,8 +1,6 @@
 # Generic types
 Address:
   "$ref": "./Address.yml"
-AddressBase32:
-  "$ref": "./AddressBase32.yml"
 Amount:
   "$ref": "./Amount.yml"
 BlockDuration:


### PR DESCRIPTION
### Fix
- Change Address to AddressBase32 format.
- Handle Namespace id and address base 32 on `UnresolvedAddress` field.
- Removed AddressBase32 schemas.

Resolved: #182 
