### PR TITLE
Update external docs URL

### DIFF
--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -7,7 +7,7 @@ paths:
   "$ref": "./routes.yml"
 externalDocs:
   description: Symbol Technical Documentation
-  url: https://docs.symbolplatform.com/
+  url: https://docs.symbol.dev/
 servers:
   - url: http://localhost:3000
     description: Local development


### PR DESCRIPTION
The old one points to the wrong site these days.