### PR TITLE
feat: use single backticks to inline API keywords

### DIFF
--- a/spec/core/account/routes/getAccountInfo.yml
+++ b/spec/core/account/routes/getAccountInfo.yml
@@ -5,7 +5,7 @@ description: |
   Retrieves account data for a given account identifier.
   The response contains the account state including balance, importance, public key, linked keys, and activity buckets.
 
-  The ``accountId`` path parameter accepts either a public key or a Base32-encoded address.
+  The `accountId` path parameter accepts either a public key or a Base32-encoded address.
 operationId: getAccountInfo
 parameters:
   - $ref: "../../../parameters/path/accountIdPath.yml"

--- a/spec/core/account/routes/getAccountInfoMerkle.yml
+++ b/spec/core/account/routes/getAccountInfoMerkle.yml
@@ -10,7 +10,7 @@ description: |
   Merkle proof response, but it is a negative proof showing that no account state entry exists
   for the requested account.
 
-  The ``accountId`` path parameter accepts either a public key or a Base32-encoded address.
+  The `accountId` path parameter accepts either a public key or a Base32-encoded address.
 operationId: getAccountInfoMerkle
 parameters:
   - $ref: "../../../parameters/path/accountIdPath.yml"

--- a/spec/core/account/routes/searchAccounts.yml
+++ b/spec/core/account/routes/searchAccounts.yml
@@ -4,10 +4,10 @@ summary: Search accounts
 description: |
   Returns a paginated list of accounts matching the given criteria.
 
-  Results can be filtered by account address and mosaic ownership, and ordered by ID or balance.
-  Standard pagination parameters (``pageSize``, ``pageNumber``, ``offset``, ``order``) apply.
-  The ``orderBy`` parameter supports ``id`` and ``balance``; when using ``orderBy=balance``,
-  the ``mosaicId`` filter is required. The ``offset`` value must match the ``orderBy`` field.
+  Results can be filtered by `address` and `mosaicId` (mosaic ownership), and ordered by `id` or `balance`.
+  Standard pagination parameters (`pageSize`, `pageNumber`, `offset`, `order`) apply.
+  The `orderBy` parameter supports `id` and `balance`; when using `orderBy=balance`,
+  the `mosaicId` filter is required. The `offset` value must match the `orderBy` field.
 operationId: searchAccounts
 parameters:
   - $ref: "../../../parameters/query/addressQuery.yml"

--- a/spec/core/block/routes/getMerkleReceipts.yml
+++ b/spec/core/block/routes/getMerkleReceipts.yml
@@ -4,7 +4,7 @@ summary: Get the Merkle path for a given receipt statement hash and block
 description: |
   Returns the [Merkle path](https://docs.symbol.dev/concepts/data-validation.html#merkle-proof)
   for a [receipt statement or resolution](https://docs.symbol.dev/concepts/receipt.html) linked to a block.
-  The ``hash`` parameter is the receipt statement hash, not the transaction hash.
+  The `hash` parameter is the receipt statement hash, not the transaction hash.
   The Merkle path is the minimum number of nodes needed to calculate the Merkle root.
 
   Steps to calculate the Merkle root:

--- a/spec/core/block/routes/searchBlocks.yml
+++ b/spec/core/block/routes/searchBlocks.yml
@@ -4,10 +4,10 @@ summary: Search blocks
 description: |
   Returns a paginated list of blocks matching the given criteria.
 
-  Results can be filtered by harvester (``signerPublicKey``), beneficiary address,
-  and timestamp range. Standard pagination parameters (``pageSize``, ``pageNumber``,
-  ``offset``, ``order``) apply.
-  The ``orderBy`` parameter supports ``id`` and ``height``. The ``offset`` value must match the ``orderBy`` field.
+  Results can be filtered by harvester (`signerPublicKey`), `beneficiaryAddress`,
+  and timestamp range. Standard pagination parameters (`pageSize`, `pageNumber`,
+  `offset`, `order`) apply.
+  The `orderBy` parameter supports `id` and `height`. The `offset` value must match the `orderBy` field.
 operationId: searchBlocks
 parameters:
   - $ref: "../../../parameters/query/signerPublicKeyQuery.yml"

--- a/spec/core/block/schemas/BlockDTO.yml
+++ b/spec/core/block/schemas/BlockDTO.yml
@@ -2,8 +2,8 @@ type: object
 description: |
   Block header data. Contains the height, timestamp, difficulty, VRF proof,
   hashes linking to the previous block, transactions, receipts, and state,
-  as well as the beneficiary address and fee multiplier.
-  The harvester is identified by `signerPublicKey`; `beneficiaryAddress` is the optional reward recipient.
+  plus `feeMultiplier` and optional `beneficiaryAddress` (reward recipient).
+  The harvester is identified by `signerPublicKey`.
 allOf:
   - $ref: "../../entity/schemas/SizePrefixedEntityDTO.yml"
   - $ref: "../../entity/schemas/VerifiableEntityDTO.yml"

--- a/spec/core/chain/schemas/ChainInfoDTO.yml
+++ b/spec/core/chain/schemas/ChainInfoDTO.yml
@@ -3,7 +3,7 @@ description: |
   Chain state: block height, chain score, and the latest finalized block (most recent
   block made permanent; it will never be rolled back).
   The chain score is the sum of all block scores in the chain; each block contributes
-  ``difficulty − time elapsed since previous block``. Higher score = better chain.
+  `difficulty − time elapsed since previous block`. Higher score = better chain.
   Used during synchronization to select the canonical chain when forks exist.
 required:
   - height
@@ -16,7 +16,7 @@ properties:
   scoreHigh:
     description: |
       High 64 bits of the 128-bit chain score. The full score is
-      ``(scoreHigh << 64) + scoreLow``. Split because JSON has no native 128-bit integer;
+      `(scoreHigh << 64) + scoreLow`. Split because JSON has no native 128-bit integer;
       the sum of millions of block scores (difficulty ~1e13 to 1e15) exceeds 64 bits.
     $ref: "../../../schemas/Score.yml"
   scoreLow:

--- a/spec/core/finalization/schemas/MessageGroup.yml
+++ b/spec/core/finalization/schemas/MessageGroup.yml
@@ -14,7 +14,7 @@ properties:
   hashes:
     type: array
     description: |
-      Block hashes voted for at this stage. Ordered by height; the first hash corresponds to ``height``,
+      Block hashes voted for at this stage. Ordered by height; the first hash corresponds to `height`,
       subsequent hashes to consecutive block heights.
     items:
       $ref: "../../../schemas/Hash256.yml"
@@ -22,6 +22,6 @@ properties:
     type: array
     description: |
       BLS aggregate signatures from the finalizer set attesting to the votes.
-      Each entry contains ``root`` and ``bottom`` of the Bm tree.
+      Each entry contains `root` and `bottom` of the Bm tree.
     items:
       $ref: "./BmTreeSignature.yml"

--- a/spec/core/network/routes/getNetworkProperties.yml
+++ b/spec/core/network/routes/getNetworkProperties.yml
@@ -2,8 +2,8 @@ tags:
   - Network routes
 summary: Get the network properties
 description: |
-  Returns the content from a catapult-server network configuration file (e.g. ``config-network.properties``).
-  To enable this feature, the REST setting ``apiNode.networkPropertyFilePath`` in the config file (e.g. ``rest.json``)
+  Returns the content from a catapult-server network configuration file (e.g. `config-network.properties`).
+  To enable this feature, the REST setting `apiNode.networkPropertyFilePath` in the config file (e.g. `rest.json`)
   must define where the file is located.
 operationId: getNetworkProperties
 responses:

--- a/spec/core/network/routes/getRentalFees.yml
+++ b/spec/core/network/routes/getRentalFees.yml
@@ -3,8 +3,8 @@ tags:
 summary: Get rental fees information
 description: |
   Returns the estimated effective rental fees for namespaces and mosaics.
-  This endpoint is only available if the REST instance has access to catapult-server ``resources/config-network.properties`` file.
-  To activate this feature, add the setting ``network.propertiesFilePath`` in the configuration file (``rest/resources/rest.json``).
+  This endpoint is only available if the REST instance has access to catapult-server `resources/config-network.properties` file.
+  To activate this feature, add the setting `network.propertiesFilePath` in the configuration file (`rest/resources/rest.json`).
 operationId: getRentalFees
 responses:
   "200":

--- a/spec/core/network/routes/getTransactionFees.yml
+++ b/spec/core/network/routes/getTransactionFees.yml
@@ -2,8 +2,8 @@ tags:
   - Network routes
 summary: Get transaction fees information
 description: |
-  Returns the average, median, highest, and lowest fee multiplier over the last ``numBlocksTransactionFeeStats`` blocks.
-  The setting ``numBlocksTransactionFeeStats`` is adjustable in the REST configuration file (``rest.json``) per REST instance.
+  Returns the average, median, highest, and lowest fee multiplier over the last `numBlocksTransactionFeeStats` blocks.
+  The setting `numBlocksTransactionFeeStats` is adjustable in the REST configuration file (`rest.json`) per REST instance.
 operationId: getTransactionFees
 responses:
   "200":

--- a/spec/core/network/schemas/TransactionFeesDTO.yml
+++ b/spec/core/network/schemas/TransactionFeesDTO.yml
@@ -1,6 +1,6 @@
 type: object
 description: |
-  Fee multiplier statistics over the last ``numBlocksTransactionFeeStats`` blocks:
+  Fee multiplier statistics over the last `numBlocksTransactionFeeStats` blocks:
   average, median, highest, lowest, and minimum on the connected node.
   All values are absolute (smallest units).
 required:
@@ -12,22 +12,22 @@ required:
 properties:
   averageFeeMultiplier:
     $ref: "../../../schemas/BlockFeeMultiplier.yml"
-    description: Average fee multiplier over the last ``numBlocksTransactionFeeStats`` blocks on the current network.
+    description: Average fee multiplier over the last `numBlocksTransactionFeeStats` blocks on the current network.
     examples:
       - 103
   medianFeeMultiplier:
     $ref: "../../../schemas/BlockFeeMultiplier.yml"
-    description: Median fee multiplier over the last ``numBlocksTransactionFeeStats`` blocks on the current network.
+    description: Median fee multiplier over the last `numBlocksTransactionFeeStats` blocks on the current network.
     examples:
       - 100
   highestFeeMultiplier:
     $ref: "../../../schemas/BlockFeeMultiplier.yml"
-    description: Highest fee multiplier over the last ``numBlocksTransactionFeeStats`` blocks on the current network.
+    description: Highest fee multiplier over the last `numBlocksTransactionFeeStats` blocks on the current network.
     examples:
       - 1136
   lowestFeeMultiplier:
     $ref: "../../../schemas/BlockFeeMultiplier.yml"
-    description: Lowest fee multiplier over the last ``numBlocksTransactionFeeStats`` blocks on the current network.
+    description: Lowest fee multiplier over the last `numBlocksTransactionFeeStats` blocks on the current network.
     examples:
       - 0
   minFeeMultiplier:

--- a/spec/core/node/routes/getNodeMetadata.yml
+++ b/spec/core/node/routes/getNodeMetadata.yml
@@ -4,20 +4,20 @@ summary: Retrieve node metadata
 description: |
   Gets the node metadata information that has been set by the node operator.
 
-  **How to set:** Add a top-level ``nodeMetadata`` object in the REST server JSON configuration
+  **How to set:** Add a top-level `nodeMetadata` object in the REST server JSON configuration
   file. Example:
 
   ```json
   {
     "nodeMetadata": {
-      "deploymentTool": "symbol-bootstrap",
+      "deploymentTool": "symbol-shoestring",
       "version": "1.0.0",
       "customLabel": "my-node"
     }
   }
   ```
 
-  The entire ``nodeMetadata`` object is served as-is; add any key-value pairs to personalize
+  The entire `nodeMetadata` object is served as-is; add any key-value pairs to personalize
   your node.
 operationId: getNodeMetadata
 responses:
@@ -29,8 +29,8 @@ responses:
           $ref: "../schemas/NodeMetadataDTO.yml"
         examples:
           nodeMetadata:
-            summary: Example node metadata (symbol-bootstrap)
+            summary: Example node metadata (symbol-shoestring)
             value:
-              deploymentTool: symbol-bootstrap
+              deploymentTool: symbol-shoestring
               version: "1.0.2"
               nodeName: api-node-0

--- a/spec/core/node/routes/getServerInfo.yml
+++ b/spec/core/node/routes/getServerInfo.yml
@@ -17,6 +17,6 @@ responses:
               serverInfo:
                 restVersion: "1.0.14"
                 deployment:
-                  deploymentTool: symbol-bootstrap
-                  deploymentToolVersion: "1.0.6"
-                  lastUpdatedDate: "2021-06-02"
+                  deploymentTool: symbol-shoestring
+                  deploymentToolVersion: "1.0.0"
+                  lastUpdatedDate: "2025-06-02"

--- a/spec/core/node/schemas/NodeMetadataDTO.yml
+++ b/spec/core/node/schemas/NodeMetadataDTO.yml
@@ -7,6 +7,6 @@ additionalProperties:
   description: The value of a user-defined metadata key.
 examples:
   -
-    deploymentTool: symbol-bootstrap
+    deploymentTool: symbol-shoestring
     version: 1.0.2
     nodeName: api-node-0

--- a/spec/core/node/schemas/RolesTypeEnum.yml
+++ b/spec/core/node/schemas/RolesTypeEnum.yml
@@ -2,19 +2,19 @@ type: integer
 description: |
   Bitmask of roles the node provides.
   Individual flags:
-  - ``0``: No roles.
-  - ``1``: Peer node.
-  - ``2``: API node.
-  - ``4``: Voting node.
-  - ``64``: IPv4 compatible node.
-  - ``128``: IPv6 compatible node.
+  - `0`: No roles.
+  - `1`: Peer node.
+  - `2`: API node.
+  - `4`: Voting node.
+  - `64`: IPv4 compatible node.
+  - `128`: IPv6 compatible node.
 
   Flags are combined with bitwise OR. Examples:
-  - ``1`` = Peer only.
-  - ``2`` = API only.
-  - ``3`` = Peer and API.
-  - ``7`` = Peer, API and Voting.
-  - ``65`` = IPv4 and Peer.
+  - `1` = Peer only.
+  - `2` = API only.
+  - `3` = Peer and API.
+  - `7` = Peer, API and Voting.
+  - `65` = IPv4 and Peer.
 
 examples:
   - 7

--- a/spec/core/transaction/routes/announceTransaction.yml
+++ b/spec/core/transaction/routes/announceTransaction.yml
@@ -14,9 +14,9 @@ description: |
   Acceptance by this node does not mean the transaction is already part of the blockchain. The
   transaction still needs to be validated and confirmed by the network.
   
-  To verify the final result, query ``GET /transactionStatus/{hash}`` on the same node that received
+  To verify the final result, query `GET /transactionStatus/{hash}` on the same node that received
   the announce request. If that node drops the transaction before propagation, other nodes may not know
-  the transaction at all and can return ``404`` for the same hash. Transaction status availability is not guaranteed
+  the transaction at all and can return `404` for the same hash. Transaction status availability is not guaranteed
   indefinitely: failed statuses are stored in a capped collection and may be evicted as new entries arrive.
 operationId: announceTransaction
 requestBody:

--- a/spec/core/transaction/routes/getConfirmedTransaction.yml
+++ b/spec/core/transaction/routes/getConfirmedTransaction.yml
@@ -5,8 +5,8 @@ description: |
   Returns confirmed transaction information given a transaction ID assigned by the node or transaction hash.
 
   Use this endpoint when you need on-chain transaction data (the transaction is already included in a block).
-  Use ``getUnconfirmedTransaction`` while the transaction is still in a node's unconfirmed pool, and
-  use ``getPartialTransaction`` for aggregate bonded transactions waiting for cosignatures.
+  Use `getUnconfirmedTransaction` while the transaction is still in a node's unconfirmed pool, and
+  use `getPartialTransaction` for aggregate bonded transactions waiting for cosignatures.
 operationId: getConfirmedTransaction
 parameters:
   - $ref: "../../../parameters/path/transactionIdPath.yml"

--- a/spec/core/transaction/routes/getConfirmedTransactions.yml
+++ b/spec/core/transaction/routes/getConfirmedTransactions.yml
@@ -5,11 +5,11 @@ description: |
   Returns confirmed transactions for the list of identifiers in the request body.
   Each request item can be either a transaction ID assigned by the node or a transaction hash.
   Both values are returned by transaction retrieval and search endpoints, for example
-  ``GET /transactions/confirmed`` and ``GET /transactions/confirmed/{transactionId}``.
+  `GET /transactions/confirmed` and `GET /transactions/confirmed/{transactionId}`.
 
   Use this endpoint when you need on-chain data for multiple transactions in one call.
-  Use ``getUnconfirmedTransactions`` for transactions still pending in a node pool, and
-  use ``getPartialTransactions`` for aggregate bonded transactions waiting for cosignatures.
+  Use `getUnconfirmedTransactions` for transactions still pending in a node pool, and
+  use `getPartialTransactions` for aggregate bonded transactions waiting for cosignatures.
 operationId: getConfirmedTransactions
 requestBody:
   $ref: "../../../request_bodies/transactionIds.yml"

--- a/spec/core/transaction/routes/getPartialTransaction.yml
+++ b/spec/core/transaction/routes/getPartialTransaction.yml
@@ -7,11 +7,11 @@ description: |
 
   The path accepts either the transaction ID assigned by the node or the transaction hash.
   Both values are returned by transaction retrieval and search endpoints, for example
-  ``GET /transactions/partial`` and ``GET /transactions/partial/{transactionId}``.
+  `GET /transactions/partial` and `GET /transactions/partial/{transactionId}`.
 
   Use this endpoint for aggregate bonded transactions before they are fully cosigned.
-  Use ``getUnconfirmedTransaction`` for non-partial transactions that are in a node's unconfirmed pool,
-  and use ``getConfirmedTransaction`` once the transaction is confirmed on-chain.
+  Use `getUnconfirmedTransaction` for non-partial transactions that are in a node's unconfirmed pool,
+  and use `getConfirmedTransaction` once the transaction is confirmed on-chain.
 operationId: getPartialTransaction
 parameters:
   - $ref: "../../../parameters/path/transactionIdPath.yml"

--- a/spec/core/transaction/routes/getPartialTransactions.yml
+++ b/spec/core/transaction/routes/getPartialTransactions.yml
@@ -7,11 +7,11 @@ description: |
 
   Each request item can be either a transaction ID assigned by the node or a transaction hash.
   Both values are returned by transaction retrieval and search endpoints, for example
-  ``GET /transactions/partial`` and ``GET /transactions/partial/{transactionId}``.
+  `GET /transactions/partial` and `GET /transactions/partial/{transactionId}`.
 
   Use this endpoint for aggregate bonded transactions that still wait for required cosignatures.
-  Use ``getUnconfirmedTransactions`` for non-partial pending transactions accepted by a node but not
-  yet included in a block, and use ``getConfirmedTransactions`` once transactions are confirmed on-chain.
+  Use `getUnconfirmedTransactions` for non-partial pending transactions accepted by a node but not
+  yet included in a block, and use `getConfirmedTransactions` once transactions are confirmed on-chain.
 operationId: getPartialTransactions
 requestBody:
   $ref: "../../../request_bodies/transactionIds.yml"

--- a/spec/core/transaction/routes/getUnconfirmedTransaction.yml
+++ b/spec/core/transaction/routes/getUnconfirmedTransaction.yml
@@ -7,10 +7,10 @@ description: |
 
   The path accepts either the transaction ID assigned by the node or the transaction hash.
   Both values are returned by transaction retrieval and search endpoints, for example
-  ``GET /transactions/unconfirmed`` and ``GET /transactions/unconfirmed/{transactionId}``.
+  `GET /transactions/unconfirmed` and `GET /transactions/unconfirmed/{transactionId}`.
 
   Use this endpoint while a transaction is accepted by a node but not yet included in a block.
-  Use ``getConfirmedTransaction`` once it is confirmed on-chain, and use ``getPartialTransaction``
+  Use `getConfirmedTransaction` once it is confirmed on-chain, and use `getPartialTransaction`
   for aggregate bonded transactions waiting for cosignatures.
 operationId: getUnconfirmedTransaction
 parameters:

--- a/spec/core/transaction/routes/getUnconfirmedTransactions.yml
+++ b/spec/core/transaction/routes/getUnconfirmedTransactions.yml
@@ -7,11 +7,11 @@ description: |
 
   Each request item can be either a transaction ID assigned by the node or a transaction hash.
   Both values are returned by transaction retrieval and search endpoints, for example
-  ``GET /transactions/unconfirmed`` and ``GET /transactions/unconfirmed/{transactionId}``.
+  `GET /transactions/unconfirmed` and `GET /transactions/unconfirmed/{transactionId}`.
 
   Use this endpoint when checking multiple transactions that are accepted by a node but not yet
-  included in a block. Use ``getConfirmedTransactions`` for on-chain transactions, and
-  use ``getPartialTransactions`` for aggregate bonded transactions waiting for cosignatures.
+  included in a block. Use `getConfirmedTransactions` for on-chain transactions, and
+  use `getPartialTransactions` for aggregate bonded transactions waiting for cosignatures.
 operationId: getUnconfirmedTransactions
 requestBody:
   $ref: "../../../request_bodies/transactionIds.yml"

--- a/spec/core/transaction/routes/searchConfirmedTransactions.yml
+++ b/spec/core/transaction/routes/searchConfirmedTransactions.yml
@@ -5,15 +5,15 @@ description: |
   Returns a paginated list of confirmed transactions matching the supplied filters.
 
   Use this endpoint when you need on-chain transactions only (already included in blocks).
-  Use ``searchUnconfirmedTransactions`` for transactions that are still pending in a node pool, and
-  use ``searchPartialTransactions`` for aggregate bonded transactions waiting for cosignatures.
+  Use `searchUnconfirmedTransactions` for transactions that are still pending in a node pool, and
+  use `searchPartialTransactions` for aggregate bonded transactions waiting for cosignatures.
 
   If a transaction was announced with an alias rather than an address, the address considered during
   filtering is the one resolved from that alias at confirmation time.
 
-  For cursor-style pagination on this endpoint, set ``offset`` to the ``id`` of the last transaction
-  from the previous page. For general pagination strategy guidance, see the ``offset`` and
-  ``pageNumber`` query parameter descriptions.
+  For cursor-style pagination on this endpoint, set `offset` to the `id` of the last transaction
+  from the previous page. For general pagination strategy guidance, see the `offset` and
+  `pageNumber` query parameter descriptions.
 operationId: searchConfirmedTransactions
 parameters:
   - $ref: "../../../parameters/query/addressQuery.yml"

--- a/spec/core/transaction/routes/searchPartialTransactions.yml
+++ b/spec/core/transaction/routes/searchPartialTransactions.yml
@@ -5,12 +5,12 @@ description: |
   Returns a paginated list of partial transactions matching the supplied filters.
 
   Use this endpoint for aggregate bonded transactions that still wait for required cosignatures.
-  Use ``searchUnconfirmedTransactions`` for non-partial pending transactions, and
-  use ``searchConfirmedTransactions`` once transactions are confirmed on-chain.
+  Use `searchUnconfirmedTransactions` for non-partial pending transactions, and
+  use `searchConfirmedTransactions` once transactions are confirmed on-chain.
 
-  For cursor-style pagination on this endpoint, set ``offset`` to the ``id`` of the last transaction
-  from the previous page. For general pagination strategy guidance, see the ``offset`` and
-  ``pageNumber`` query parameter descriptions.
+  For cursor-style pagination on this endpoint, set `offset` to the `id` of the last transaction
+  from the previous page. For general pagination strategy guidance, see the `offset` and
+  `pageNumber` query parameter descriptions.
 operationId: searchPartialTransactions
 parameters:
   - $ref: "../../../parameters/query/addressQuery.yml"

--- a/spec/core/transaction/routes/searchUnconfirmedTransactions.yml
+++ b/spec/core/transaction/routes/searchUnconfirmedTransactions.yml
@@ -5,12 +5,12 @@ description: |
   Returns a paginated list of unconfirmed transactions matching the supplied filters.
 
   Use this endpoint for transactions accepted by a node but not yet included in a block.
-  Use ``searchConfirmedTransactions`` for on-chain transactions, and use
-  ``searchPartialTransactions`` for aggregate bonded transactions waiting for cosignatures.
+  Use `searchConfirmedTransactions` for on-chain transactions, and use
+  `searchPartialTransactions` for aggregate bonded transactions waiting for cosignatures.
 
-  For cursor-style pagination on this endpoint, set ``offset`` to the ``id`` of the last transaction
-  from the previous page. For general pagination strategy guidance, see the ``offset`` and
-  ``pageNumber`` query parameter descriptions.
+  For cursor-style pagination on this endpoint, set `offset` to the `id` of the last transaction
+  from the previous page. For general pagination strategy guidance, see the `offset` and
+  `pageNumber` query parameter descriptions.
 operationId: searchUnconfirmedTransactions
 parameters:
   - $ref: "../../../parameters/query/addressQuery.yml"

--- a/spec/core/transaction/schemas/AnnounceTransactionInfoDTO.yml
+++ b/spec/core/transaction/schemas/AnnounceTransactionInfoDTO.yml
@@ -8,9 +8,9 @@ description: |
   Acceptance by a node does not mean the transaction is already part of the blockchain. The
   transaction still needs to be validated and confirmed by the network.
 
-  To verify the final result, query ``GET /transactionStatus/{hash}`` on the same node that received
+  To verify the final result, query `GET /transactionStatus/{hash}` on the same node that received
   the announce request. If that node drops the transaction before propagation, other nodes may not
-  know the transaction at all and can return ``404`` for the same hash.
+  know the transaction at all and can return `404` for the same hash.
   
   In some cases the transaction can be dropped without any failure status being returned. Common causes include using
   a fee below the minimum accepted by that node or using a generation hash seed that does not match the target network.

--- a/spec/core/transaction/schemas/EmbeddedTransactionMetaDTO.yml
+++ b/spec/core/transaction/schemas/EmbeddedTransactionMetaDTO.yml
@@ -12,7 +12,7 @@ properties:
     $ref: "../../../schemas/TransactionMetaHeight.yml"
     description: |
       Height of the block that contains the parent aggregate transaction.
-      For embedded transactions returned from partial aggregate transactions, this value is ``"0"``.
+      For embedded transactions returned from partial aggregate transactions, this value is `"0"`.
   aggregateHash:
     $ref: "../../../schemas/Hash256.yml"
     description: Hash of the parent aggregate transaction.

--- a/spec/core/transaction/schemas/TransactionInfoDTO.yml
+++ b/spec/core/transaction/schemas/TransactionInfoDTO.yml
@@ -3,9 +3,9 @@ description: |
   Transaction record returned by transaction lookup and search endpoints.
   
   The same wrapper is used for confirmed, unconfirmed, and partial transaction groups. The exact
-  ``meta`` shape depends on whether the returned entry is a top-level transaction or an embedded
+  `meta` shape depends on whether the returned entry is a top-level transaction or an embedded
   transaction inside an aggregate. When an aggregate transaction is retrieved by ID or hash, REST can
-  also expand its embedded transactions under ``transaction.transactions``.
+  also expand its embedded transactions under `transaction.transactions`.
 required:
   - id
   - meta
@@ -16,14 +16,14 @@ properties:
   meta:
     description: |
       Metadata for the returned transaction entry.
-      Top-level entries use ``TransactionMetaDTO``. Embedded entries use ``EmbeddedTransactionMetaDTO``.
+      Top-level entries use `TransactionMetaDTO`. Embedded entries use `EmbeddedTransactionMetaDTO`.
     anyOf:
       - $ref: "./TransactionMetaDTO.yml"
       - $ref: "./EmbeddedTransactionMetaDTO.yml"
   transaction:
     description: |
       Concrete transaction payload represented by one of the listed transaction DTOs.
-      For aggregate transaction lookups, REST can populate ``transaction.transactions`` with the
+      For aggregate transaction lookups, REST can populate `transaction.transactions` with the
       embedded transaction records linked to that aggregate.
     anyOf:
       - $ref: "../../../plugins/account_link/schemas/AccountKeyLinkTransactionDTO.yml"

--- a/spec/core/transaction/schemas/TransactionMetaDTO.yml
+++ b/spec/core/transaction/schemas/TransactionMetaDTO.yml
@@ -5,12 +5,12 @@ description: |
   proof-related hashes associated with that block entry.
 
   For unconfirmed top-level transactions, REST returns:
-  - ``height`` = ``"0"``
-  - ``index`` = ``0``
-  - ``hash`` = transaction hash
-  - ``merkleComponentHash`` = transaction hash
+  - `height` = `"0"`
+  - `index` = `0`
+  - `hash` = transaction hash
+  - `merkleComponentHash` = transaction hash
 
-  Block-derived fields such as ``timestamp`` and ``feeMultiplier`` are not present until the transaction
+  Block-derived fields such as `timestamp` and `feeMultiplier` are not present until the transaction
   is included in a block.
 required:
   - height
@@ -20,7 +20,7 @@ required:
 properties:
   height:
     $ref: "../../../schemas/TransactionMetaHeight.yml"
-    description: Height of the block that contains the transaction. For unconfirmed top-level transactions, this value is ``"0"``.
+    description: Height of the block that contains the transaction. For unconfirmed top-level transactions, this value is `"0"`.
   hash:
     $ref: "../../../schemas/Hash256.yml"
     description: Hash of the top-level transaction.
@@ -28,11 +28,11 @@ properties:
     $ref: "../../../schemas/Hash256.yml"
     description: |
       Merkle component hash of the top-level transaction used in block transaction proofs.
-      For unconfirmed top-level transactions, this value matches ``hash``.
+      For unconfirmed top-level transactions, this value matches `hash`.
   index:
     type: integer
     description: |
-      Transaction index within the block. For unconfirmed top-level transactions, this value is ``0``.
+      Transaction index within the block. For unconfirmed top-level transactions, this value is `0`.
   timestamp:
     $ref: "../../../schemas/Timestamp.yml"
     description: |

--- a/spec/parameters/query/addressQuery.yml
+++ b/spec/parameters/query/addressQuery.yml
@@ -9,7 +9,7 @@ description: |
   - account restriction search: matches the restricted account address
   - hash lock and secret lock search: matches the lock owner address
 
-  On transaction search endpoints, this filter cannot be combined with ``recipientAddress`` and
-  ``signerPublicKey``.
+  On transaction search endpoints, this filter cannot be combined with `recipientAddress` and
+  `signerPublicKey`.
 schema:
   $ref: "../../schemas/Address.yml"

--- a/spec/parameters/query/embeddedQuery.yml
+++ b/spec/parameters/query/embeddedQuery.yml
@@ -1,26 +1,26 @@
 name: embedded
 in: query
 description: |
-  When ``true``, the search also includes transactions embedded inside aggregate transactions.
+  When `true`, the search also includes transactions embedded inside aggregate transactions.
   Otherwise, only top-level transactions are returned.
 
   Results are **flattened**. Embedded transactions are returned as separate entries in the same
-  ``data`` array as top-level transactions, not nested under their parent aggregate transaction.
+  `data` array as top-level transactions, not nested under their parent aggregate transaction.
   Sorting, filtering, and pagination are therefore applied to one combined result set containing
   both top-level and embedded transaction records.
 
   In the database, embedded transactions are stored as separate documents linked to their
-  parent aggregate by ``meta.aggregateId`` and ``meta.aggregateHash``. When ``embedded=false``, the
-  search excludes documents with ``meta.aggregateId``. When ``embedded=true``, those documents are
+  parent aggregate by `meta.aggregateId` and `meta.aggregateHash`. When `embedded=false`, the
+  search excludes documents with `meta.aggregateId`. When `embedded=true`, those documents are
   included in the page result alongside regular transactions. In REST responses, embedded entries
-  are identified by ``meta.aggregateId``, ``meta.aggregateHash``, and their inner ``meta.index``;
-  unlike top-level transactions, they do not carry their own ``meta.hash``.
+  are identified by `meta.aggregateId`, `meta.aggregateHash`, and their inner `meta.index`;
+  unlike top-level transactions, they do not carry their own `meta.hash`.
 
-  **Note:** This field does not work as expected with the ``address`` filter. That filter matches the
-  internal ``meta.addresses`` field used on top-level transaction documents, while embedded
+  **Note:** This field does not work as expected with the `address` filter. That filter matches the
+  internal `meta.addresses` field used on top-level transaction documents, while embedded
   transaction documents do not carry that field. As a result, embedded transactions involving the
-  specified address will not be returned even when ``embedded=true``. Filters such as
-  ``recipientAddress`` and ``signerPublicKey`` do not have this limitation.
+  specified address will not be returned even when `embedded=true`. Filters such as
+  `recipientAddress` and `signerPublicKey` do not have this limitation.
 schema:
   type: boolean
   default: false

--- a/spec/parameters/query/orderByAccountQuery.yml
+++ b/spec/parameters/query/orderByAccountQuery.yml
@@ -2,7 +2,7 @@ name: orderBy
 in: query
 description: |
   Sort responses by the property set.
-  If ``balance`` option is selected, the request must define the ``mosaicId`` filter.
+  If `balance` option is selected, the request must define the `mosaicId` filter.
 schema:
   $ref: "../../core/account/schemas/AccountOrderByEnum.yml"
   default: id

--- a/spec/parameters/query/orderByBlockQuery.yml
+++ b/spec/parameters/query/orderByBlockQuery.yml
@@ -1,6 +1,6 @@
 name: orderBy
 in: query
 description: |
-  Sort responses by the property set. Defaults to ``id`` when not specified.
+  Sort responses by the property set. Defaults to `id` when not specified.
 schema:
   $ref: "../../core/block/schemas/BlockOrderByEnum.yml"

--- a/spec/parameters/query/orderQuery.yml
+++ b/spec/parameters/query/orderQuery.yml
@@ -1,8 +1,8 @@
 name: order
 in: query
 description: |
-  Sort responses in ascending or descending order based on the collection property set on the param ``orderBy``.
-  If the request does not specify ``orderBy``, REST returns the collection ordered by id.
+  Sort responses in ascending or descending order based on the collection property set on the param `orderBy`.
+  If the request does not specify `orderBy`, REST returns the collection ordered by id.
   The default sort direction depends on the endpoint implementation.
 schema:
   $ref: "../../schemas/Order.yml"

--- a/spec/parameters/query/transactionTypesQuery.yml
+++ b/spec/parameters/query/transactionTypesQuery.yml
@@ -2,7 +2,7 @@ name: type
 in: query
 description: |
   Filter by transaction type (include).
-  To match multiple transaction types, add more query parameters like: ``type=16974&type=16718``.
+  To match multiple transaction types, add more query parameters like: `type=16974&type=16718`.
 style: form
 explode: true
 schema:

--- a/spec/plugins/account_link/schemas/EmbeddedAccountKeyLinkTransactionDTO.yml
+++ b/spec/plugins/account_link/schemas/EmbeddedAccountKeyLinkTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``AccountKeyLinkTransactionDTO``.
+description: Embedded transaction variant of `AccountKeyLinkTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./AccountKeyLinkTransactionBodyDTO.yml"

--- a/spec/plugins/account_link/schemas/EmbeddedNodeKeyLinkTransactionDTO.yml
+++ b/spec/plugins/account_link/schemas/EmbeddedNodeKeyLinkTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``NodeKeyLinkTransactionDTO``.
+description: Embedded transaction variant of `NodeKeyLinkTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./NodeKeyLinkTransactionBodyDTO.yml"

--- a/spec/plugins/aggregate/routes/announcePartialTransaction.yml
+++ b/spec/plugins/aggregate/routes/announcePartialTransaction.yml
@@ -11,9 +11,9 @@ description: |
   Acceptance by this node does not mean the transaction is already part of the blockchain. The
   transaction still needs to be validated and confirmed by the network.
   
-  To verify the final result, query ``GET /transactionStatus/{hash}`` on the same node that received
+  To verify the final result, query `GET /transactionStatus/{hash}` on the same node that received
   the announce request. If that node drops the transaction before propagation, other nodes may not
-  know the transaction at all and can return ``404`` for the same hash. Transaction status availability is not guaranteed
+  know the transaction at all and can return `404` for the same hash. Transaction status availability is not guaranteed
   indefinitely: failed statuses are stored in a capped collection and may be evicted as new entries arrive.
 operationId: announcePartialTransaction
 requestBody:

--- a/spec/plugins/coresystem/schemas/EmbeddedVotingKeyLinkTransactionDTO.yml
+++ b/spec/plugins/coresystem/schemas/EmbeddedVotingKeyLinkTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``VotingKeyLinkTransactionDTO``.
+description: Embedded transaction variant of `VotingKeyLinkTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./VotingKeyLinkTransactionBodyDTO.yml"

--- a/spec/plugins/coresystem/schemas/EmbeddedVrfKeyLinkTransactionDTO.yml
+++ b/spec/plugins/coresystem/schemas/EmbeddedVrfKeyLinkTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``VrfKeyLinkTransactionDTO``.
+description: Embedded transaction variant of `VrfKeyLinkTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./VrfKeyLinkTransactionBodyDTO.yml"

--- a/spec/plugins/lock_hash/schemas/EmbeddedHashLockTransactionDTO.yml
+++ b/spec/plugins/lock_hash/schemas/EmbeddedHashLockTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``HashLockTransactionDTO``.
+description: Embedded transaction variant of `HashLockTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./HashLockTransactionBodyDTO.yml"

--- a/spec/plugins/lock_secret/schemas/EmbeddedSecretLockTransactionDTO.yml
+++ b/spec/plugins/lock_secret/schemas/EmbeddedSecretLockTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``SecretLockTransactionDTO``.
+description: Embedded transaction variant of `SecretLockTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./SecretLockTransactionBodyDTO.yml"

--- a/spec/plugins/lock_secret/schemas/EmbeddedSecretProofTransactionDTO.yml
+++ b/spec/plugins/lock_secret/schemas/EmbeddedSecretProofTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``SecretProofTransactionDTO``.
+description: Embedded transaction variant of `SecretProofTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./SecretProofTransactionBodyDTO.yml"

--- a/spec/plugins/lock_secret/schemas/SecretProofTransactionBodyDTO.yml
+++ b/spec/plugins/lock_secret/schemas/SecretProofTransactionBodyDTO.yml
@@ -14,5 +14,5 @@ properties:
     $ref: "./LockHashAlgorithmEnum.yml"
   proof:
     type: string
-    description: Proof data whose hash, using ``hashAlgorithm``, must match ``secret``.
+    description: Proof data whose hash, using `hashAlgorithm`, must match `secret`.
 

--- a/spec/plugins/metadata/schemas/EmbeddedAccountMetadataTransactionDTO.yml
+++ b/spec/plugins/metadata/schemas/EmbeddedAccountMetadataTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``AccountMetadataTransactionDTO``.
+description: Embedded transaction variant of `AccountMetadataTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./AccountMetadataTransactionBodyDTO.yml"

--- a/spec/plugins/metadata/schemas/EmbeddedMosaicMetadataTransactionDTO.yml
+++ b/spec/plugins/metadata/schemas/EmbeddedMosaicMetadataTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``MosaicMetadataTransactionDTO``.
+description: Embedded transaction variant of `MosaicMetadataTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./MosaicMetadataTransactionBodyDTO.yml"

--- a/spec/plugins/metadata/schemas/EmbeddedNamespaceMetadataTransactionDTO.yml
+++ b/spec/plugins/metadata/schemas/EmbeddedNamespaceMetadataTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``NamespaceMetadataTransactionDTO``.
+description: Embedded transaction variant of `NamespaceMetadataTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./NamespaceMetadataTransactionBodyDTO.yml"

--- a/spec/plugins/mosaic/schemas/EmbeddedMosaicDefinitionTransactionDTO.yml
+++ b/spec/plugins/mosaic/schemas/EmbeddedMosaicDefinitionTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``MosaicDefinitionTransactionDTO``.
+description: Embedded transaction variant of `MosaicDefinitionTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./MosaicDefinitionTransactionBodyDTO.yml"

--- a/spec/plugins/mosaic/schemas/EmbeddedMosaicSupplyChangeTransactionDTO.yml
+++ b/spec/plugins/mosaic/schemas/EmbeddedMosaicSupplyChangeTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``MosaicSupplyChangeTransactionDTO``.
+description: Embedded transaction variant of `MosaicSupplyChangeTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./MosaicSupplyChangeTransactionBodyDTO.yml"

--- a/spec/plugins/mosaic/schemas/EmbeddedMosaicSupplyRevocationTransactionDTO.yml
+++ b/spec/plugins/mosaic/schemas/EmbeddedMosaicSupplyRevocationTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``MosaicSupplyRevocationTransactionDTO``.
+description: Embedded transaction variant of `MosaicSupplyRevocationTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./MosaicSupplyRevocationTransactionBodyDTO.yml"

--- a/spec/plugins/mosaic/schemas/MosaicNetworkPropertiesDTO.yml
+++ b/spec/plugins/mosaic/schemas/MosaicNetworkPropertiesDTO.yml
@@ -1,6 +1,6 @@
 type: object
 description: |
-  Mosaic plugin settings from network configuration (``/network/properties``).
+  Mosaic plugin settings from network configuration (`/network/properties`).
   Values from Symbol mainnet.
 properties:
   maxMosaicsPerAccount:
@@ -10,7 +10,7 @@ properties:
       - "1'000"
   maxMosaicDuration:
     type: string
-    description: Maximum mosaic duration (BlockSpan format, e.g. ``3650d`` for 3650 days).
+    description: Maximum mosaic duration (BlockSpan format, e.g. `3650d` for 3650 days).
     examples:
       - 3650d
   maxMosaicDivisibility:

--- a/spec/plugins/multisig/schemas/EmbeddedMultisigAccountModificationTransactionDTO.yml
+++ b/spec/plugins/multisig/schemas/EmbeddedMultisigAccountModificationTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``MultisigAccountModificationTransactionDTO``.
+description: Embedded transaction variant of `MultisigAccountModificationTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./MultisigAccountModificationTransactionBodyDTO.yml"

--- a/spec/plugins/namespace/routes/getMosaicsNames.yml
+++ b/spec/plugins/namespace/routes/getMosaicsNames.yml
@@ -7,7 +7,7 @@ description: |
   Submit an array of mosaic identifiers in the request body. For each requested
   mosaic identifier, the response returns one entry in the same order as the request.
   Each entry contains the namespace names currently linked to that identifier. An
-  empty ``names`` array means no namespace aliases were resolved for that identifier.
+  empty `names` array means no namespace aliases were resolved for that identifier.
 operationId: getMosaicsNames
 requestBody:
   $ref: "../../../request_bodies/mosaicIds.yml"

--- a/spec/plugins/namespace/schemas/AliasDTO.yml
+++ b/spec/plugins/namespace/schemas/AliasDTO.yml
@@ -1,7 +1,7 @@
 type: object
 description: |
   Alias currently linked to the namespace.
-  Depending on ``type``, the namespace either has no alias, points to a mosaic ID, or points to an account address.
+  Depending on `type`, the namespace either has no alias, points to a mosaic ID, or points to an account address.
 required:
   - type
 properties:
@@ -9,7 +9,7 @@ properties:
     $ref: "./AliasTypeEnum.yml"
   mosaicId:
     $ref: "../../../schemas/MosaicId.yml"
-    description: Mosaic identifier linked by the namespace when ``type`` is ``1``.
+    description: Mosaic identifier linked by the namespace when `type` is `1`.
   address:
     $ref: "../../../schemas/AddressHex.yml"
-    description: Account address linked by the namespace when ``type`` is ``2``.
+    description: Account address linked by the namespace when `type` is `2`.

--- a/spec/plugins/namespace/schemas/EmbeddedAddressAliasTransactionDTO.yml
+++ b/spec/plugins/namespace/schemas/EmbeddedAddressAliasTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``AddressAliasTransactionDTO``.
+description: Embedded transaction variant of `AddressAliasTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./AddressAliasTransactionBodyDTO.yml"

--- a/spec/plugins/namespace/schemas/EmbeddedMosaicAliasTransactionDTO.yml
+++ b/spec/plugins/namespace/schemas/EmbeddedMosaicAliasTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``MosaicAliasTransactionDTO``.
+description: Embedded transaction variant of `MosaicAliasTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./MosaicAliasTransactionBodyDTO.yml"

--- a/spec/plugins/namespace/schemas/EmbeddedNamespaceRegistrationTransactionDTO.yml
+++ b/spec/plugins/namespace/schemas/EmbeddedNamespaceRegistrationTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``NamespaceRegistrationTransactionDTO``.
+description: Embedded transaction variant of `NamespaceRegistrationTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./NamespaceRegistrationTransactionBodyDTO.yml"

--- a/spec/plugins/namespace/schemas/MosaicNamesDTO.yml
+++ b/spec/plugins/namespace/schemas/MosaicNamesDTO.yml
@@ -1,7 +1,7 @@
 type: object
 description: |
   Resolved namespace names linked to a specific mosaic identifier.
-  An empty ``names`` array means no namespace aliases were resolved for that
+  An empty `names` array means no namespace aliases were resolved for that
   identifier.
 required:
   - mosaicId

--- a/spec/plugins/namespace/schemas/NamespaceDTO.yml
+++ b/spec/plugins/namespace/schemas/NamespaceDTO.yml
@@ -19,7 +19,7 @@ properties:
     type: integer
     description: |
       Number of levels present in the namespace path.
-      This matches how many namespace IDs are defined across ``level0``, ``level1``, and ``level2``.
+      This matches how many namespace IDs are defined across `level0`, `level1`, and `level2`.
     examples:
       - 1
   level0:

--- a/spec/plugins/restriction_account/schemas/EmbeddedAccountAddressRestrictionTransactionDTO.yml
+++ b/spec/plugins/restriction_account/schemas/EmbeddedAccountAddressRestrictionTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``AccountAddressRestrictionTransactionDTO``.
+description: Embedded transaction variant of `AccountAddressRestrictionTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./AccountAddressRestrictionTransactionBodyDTO.yml"

--- a/spec/plugins/restriction_account/schemas/EmbeddedAccountMosaicRestrictionTransactionDTO.yml
+++ b/spec/plugins/restriction_account/schemas/EmbeddedAccountMosaicRestrictionTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``AccountMosaicRestrictionTransactionDTO``.
+description: Embedded transaction variant of `AccountMosaicRestrictionTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./AccountMosaicRestrictionTransactionBodyDTO.yml"

--- a/spec/plugins/restriction_account/schemas/EmbeddedAccountOperationRestrictionTransactionDTO.yml
+++ b/spec/plugins/restriction_account/schemas/EmbeddedAccountOperationRestrictionTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``AccountOperationRestrictionTransactionDTO``.
+description: Embedded transaction variant of `AccountOperationRestrictionTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./AccountOperationRestrictionTransactionBodyDTO.yml"

--- a/spec/plugins/restriction_mosaic/schemas/EmbeddedMosaicAddressRestrictionTransactionDTO.yml
+++ b/spec/plugins/restriction_mosaic/schemas/EmbeddedMosaicAddressRestrictionTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``MosaicAddressRestrictionTransactionDTO``.
+description: Embedded transaction variant of `MosaicAddressRestrictionTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./MosaicAddressRestrictionTransactionBodyDTO.yml"

--- a/spec/plugins/restriction_mosaic/schemas/EmbeddedMosaicGlobalRestrictionTransactionDTO.yml
+++ b/spec/plugins/restriction_mosaic/schemas/EmbeddedMosaicGlobalRestrictionTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``MosaicGlobalRestrictionTransactionDTO``.
+description: Embedded transaction variant of `MosaicGlobalRestrictionTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./MosaicGlobalRestrictionTransactionBodyDTO.yml"

--- a/spec/plugins/transfer/schemas/EmbeddedTransferTransactionDTO.yml
+++ b/spec/plugins/transfer/schemas/EmbeddedTransferTransactionDTO.yml
@@ -1,5 +1,5 @@
 type: object
-description: Embedded transaction variant of ``TransferTransactionDTO``.
+description: Embedded transaction variant of `TransferTransactionDTO`.
 allOf:
   - $ref: "../../../core/transaction/schemas/EmbeddedTransactionDTO.yml"
   - $ref: "./TransferTransactionBodyDTO.yml"

--- a/spec/request_bodies/schemas/accountIds.yml
+++ b/spec/request_bodies/schemas/accountIds.yml
@@ -1,6 +1,6 @@
 type: object
 description: |
-  Request body for batch account lookup. Provide either ``publicKeys`` or ``addresses``, not both.
+  Request body for batch account lookup. Provide either `publicKeys` or `addresses`, not both.
   At least one must be non-empty.
 properties:
   publicKeys:

--- a/spec/schemas/AddressHex.yml
+++ b/spec/schemas/AddressHex.yml
@@ -1,7 +1,7 @@
 type: string
 description: |
   Address encoded as a 48-character hexadecimal string (24 bytes).
-  The REST API returns addresses in this format. For Base32-encoded addresses (39 chars) see ``Address``.
+  The REST API returns addresses in this format. For Base32-encoded addresses (39 chars) see `Address`.
 pattern: '^[0-9a-fA-F]+$'
 minLength: 48
 maxLength: 48

--- a/spec/schemas/BlockFeeMultiplier.yml
+++ b/spec/schemas/BlockFeeMultiplier.yml
@@ -8,11 +8,11 @@ description: |
 
   The effective fee for a transaction is:
 
-  ``effectiveFee = transaction.size × block.feeMultiplier``
+  `effectiveFee = transaction.size × block.feeMultiplier`
 
   Node owners can configure the fee multiplier to any non-negative value (including zero).
   For transaction senders, the median fee multiplier over recent blocks is available
-  via ``/network/fees/transaction``; using ``medianFeeMultiplier`` or higher
+  via `/network/fees/transaction`; using `medianFeeMultiplier` or higher
   improves chances of inclusion. See the [fees documentation](https://docs.symbol.dev/concepts/fees.html).
 examples:
   - 0

--- a/spec/schemas/Difficulty.yml
+++ b/spec/schemas/Difficulty.yml
@@ -2,7 +2,7 @@ type: string
 description: |
   Block difficulty. Determines how hard it is to harvest a new block, based on previous blocks.
   The initial difficulty is 100'000'000'000'000 (1e14) and remains at this level as long as blocks
-  are generated every ``blockGenerationTargetTime`` seconds (network property).
+  are generated every `blockGenerationTargetTime` seconds (network property).
   When block generation times deviate from the target, the difficulty is adjusted dynamically
   in the range of 10'000'000'000'000 (1e13) to 100'000'000'000'000'000 (1e15) to maintain
   the target block creation rate. See the

--- a/spec/schemas/ObjectId.yml
+++ b/spec/schemas/ObjectId.yml
@@ -1,7 +1,7 @@
 type: string
 description: |
   Unique identifier of the object in the node's database (MongoDB ObjectId).
-  Used as the ``offset`` parameter value for cursor-based pagination.
+  Used as the `offset` parameter value for cursor-based pagination.
 minLength: 24
 maxLength: 24
 pattern: '^[0-9a-fA-F]+$'

--- a/spec/schemas/ProofGamma.yml
+++ b/spec/schemas/ProofGamma.yml
@@ -6,6 +6,6 @@ description: |
   32-byte (64 hex characters) VRF proof gamma. Part of the block's
   [generation hash proof](https://docs.symbol.dev/concepts/block.html#header) (VrfProof).
   The gamma value is the first component of the VRF output; it is combined with
-  ``proofScalar`` and ``proofVerificationHash`` to form the complete verifiable proof.
+  `proofScalar` and `proofVerificationHash` to form the complete verifiable proof.
 examples:
   - 8D49594A96C31EC6C64305FB2CCB47AA7A4AC0A4F614442BB3684D2BF41F274E

--- a/spec/schemas/ProofVerificationHash.yml
+++ b/spec/schemas/ProofVerificationHash.yml
@@ -5,7 +5,7 @@ maxLength: 32
 description: |
   16-byte (32 hex characters) VRF proof verification hash. Part of the block's
   [generation hash proof](https://docs.symbol.dev/concepts/block.html#header) (VrfProof),
-  together with ``proofGamma`` and ``proofScalar``.
+  together with `proofGamma` and `proofScalar`.
   The harvester generates this proof using its VRF private key; the verification hash
   allows anyone with the VRF public key to verify that the proof was correctly computed
   without revealing the private key.

--- a/spec/schemas/Score.yml
+++ b/spec/schemas/Score.yml
@@ -1,7 +1,7 @@
 type: string
 description: |
   64-bit part of the full 128-bit chain score. The full score is
-  ``(scoreHigh << 64) + scoreLow``. Each block adds ``difficulty − time elapsed since previous block``;
+  `(scoreHigh << 64) + scoreLow`. Each block adds `difficulty − time elapsed since previous block`;
   the chain score is the sum. During synchronization, nodes select the chain with the highest score.
 examples:
   - 1683298087010368306

--- a/spec/schemas/Timestamp.yml
+++ b/spec/schemas/Timestamp.yml
@@ -3,12 +3,12 @@ description: |
   Network timestamp in **milliseconds** since the creation of the nemesis (first) block.
   Used for block timestamps, transaction deadlines, and time synchronization.
 
-  **Finding the nemesis block time:** The ``epochAdjustment`` field returned by the
-  [``/network/properties``] endpoint gives the nemesis block creation time in seconds since the
+  **Finding the nemesis block time:** The `epochAdjustment` field returned by the
+  [`/network/properties`] endpoint gives the nemesis block creation time in seconds since the
   [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time). For Symbol MAINNET this is
-  always ``1615853185`` (15 March 2021, 00:06:25 UTC).
+  always `1615853185` (15 March 2021, 00:06:25 UTC).
 
-  **Converting to real time:** Add this timestamp (ms) to ``epochAdjustment × 1000`` (ms), then use standard date functions.
-  Note: ``epochAdjustment`` may be returned as a string like ``"1615853185s"``; use the numeric part.
+  **Converting to real time:** Add this timestamp (ms) to `epochAdjustment × 1000` (ms), then use standard date functions.
+  Note: `epochAdjustment` may be returned as a string like `"1615853185s"`; use the numeric part.
 examples:
   - "108303181802"

--- a/spec/schemas/TransactionMetaHeight.yml
+++ b/spec/schemas/TransactionMetaHeight.yml
@@ -1,7 +1,7 @@
 type: string
 description: |
   Height of the block containing the referenced transaction or parent aggregate transaction.
-  Returned as a decimal string. The value is ``"0"`` when the transaction is not included in a
+  Returned as a decimal string. The value is `"0"` when the transaction is not included in a
   block yet, for example for unconfirmed transactions and partial aggregate transactions.
 pattern: '^(0|[1-9][0-9]*)$'
 examples:


### PR DESCRIPTION
## Description

Use single backticks for inline API identifiers in descriptions; convert double-backtick.