### PR TITLE
feat: transactionId examples, change accountId schema to string

### DIFF
--- a/spec/parameters/path/accountIdPath.yml
+++ b/spec/parameters/path/accountIdPath.yml
@@ -3,9 +3,7 @@ in: path
 description: Account identifier. Accepts either a public key or a Base32-encoded address.
 required: true
 schema:
-  oneOf:
-    - $ref: "../../schemas/PublicKey.yml"
-    - $ref: "../../schemas/Address.yml"
+  type: string
 examples:
   testnetAddress:
     summary: Testnet address (Base32, prefix T)

--- a/spec/parameters/path/accountIdPath.yml
+++ b/spec/parameters/path/accountIdPath.yml
@@ -1,9 +1,12 @@
 name: accountId
 in: path
-description: Account identifier. Accepts either a public key or a Base32-encoded address.
+description: |
+  Account public key as 64 hexadecimal characters, or account address as 39 Base32
+  (network prefix `T` for testnet, `N` for mainnet).
 required: true
 schema:
   type: string
+  pattern: '^(?:[0-9a-fA-F]{64}|[A-Z2-7]{39})$'
 examples:
   testnetAddress:
     summary: Testnet address (Base32, prefix T)

--- a/spec/parameters/path/transactionIdPath.yml
+++ b/spec/parameters/path/transactionIdPath.yml
@@ -1,9 +1,11 @@
 name: transactionId
 in: path
-description: Transaction ID assigned by the node or transaction hash.
+description: |
+  Transaction hash (64 hexadecimal characters) or node-assigned transaction id (16 hexadecimal characters).
 required: true
 schema:
   type: string
+  pattern: '^(?:[0-9a-fA-F]{64}|[0-9a-fA-F]{16})$'
 examples:
   transactionHash:
     summary: Transaction hash (hex)

--- a/spec/parameters/path/transactionIdPath.yml
+++ b/spec/parameters/path/transactionIdPath.yml
@@ -1,7 +1,7 @@
 name: transactionId
 in: path
 description: |
-  Transaction hash (64 hexadecimal characters) or node-assigned transaction id (16 hexadecimal characters).
+  Transaction hash (64 hexadecimal characters) or node-assigned transaction ID (16 hexadecimal characters).
 required: true
 schema:
   type: string
@@ -11,5 +11,5 @@ examples:
     summary: Transaction hash (hex)
     value: 73C5E3F46E2D24A3A1B9959DD62A42A54A0882F3DF2D72A6917C57C67D7A5B8A
   transactionId:
-    summary: Database transaction id
+    summary: Database transaction ID
     value: 0DC67FBE1CAD29E3

--- a/spec/parameters/path/transactionIdPath.yml
+++ b/spec/parameters/path/transactionIdPath.yml
@@ -4,3 +4,10 @@ description: Transaction ID assigned by the node or transaction hash.
 required: true
 schema:
   type: string
+examples:
+  transactionHash:
+    summary: Transaction hash (hex)
+    value: 73C5E3F46E2D24A3A1B9959DD62A42A54A0882F3DF2D72A6917C57C67D7A5B8A
+  transactionId:
+    summary: Database transaction id
+    value: 0DC67FBE1CAD29E3


### PR DESCRIPTION
## Summary
- Document sample values for the `transactionId` path parameter (transaction hash vs node-assigned id).
- Simplify the `accountId` path parameter to a plain `string` schema (removes `oneOf` with `PublicKey` / `Address` $refs).

## Motivation
This simplifies code generation with OpenAPI generators.
